### PR TITLE
DSP-13102 improve WWW-Authenticate header parsing

### DIFF
--- a/alfredo/pom.xml
+++ b/alfredo/pom.xml
@@ -64,6 +64,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>24.0-jre</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>servlet-api</artifactId>
             <scope>provided</scope>

--- a/alfredo/src/main/java/com/cloudera/alfredo/client/AuthenticatedURL.java
+++ b/alfredo/src/main/java/com/cloudera/alfredo/client/AuthenticatedURL.java
@@ -25,6 +25,7 @@ import java.net.HttpURLConnection;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.HttpsURLConnection;
 import java.net.URL;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
@@ -323,8 +324,7 @@ public class AuthenticatedURL {
      */
     public static void extractToken(HttpURLConnection conn, Token token) throws IOException, AuthenticationException {
         if (conn.getResponseCode() == HttpURLConnection.HTTP_OK) {
-            Map<String, List<String>> headers = conn.getHeaderFields();
-            List<String> cookies = headers.get("Set-Cookie");
+            List<String> cookies = readHeaderField(conn, "Set-Cookie");
             if (cookies != null) {
                 for (String cookie : cookies) {
                     if (cookie.startsWith(AUTH_COOKIE_EQ)) {
@@ -346,4 +346,21 @@ public class AuthenticatedURL {
         }
     }
 
+    private static List<String> safeAddAll(List<String> target, List<String> values) {
+        if (values != null) {
+            target.addAll(values);
+        }
+        return target;
+    }
+
+    public static List<String> readHeaderField(HttpURLConnection connection, String header) {
+        Map<String, List<String>> headerFields = connection.getHeaderFields();
+        List<String> headerValues = new LinkedList<String>();
+        for (Map.Entry<String, List<String>> h : headerFields.entrySet()) {
+            if (header.equalsIgnoreCase(h.getKey())) {
+                safeAddAll(headerValues, h.getValue());
+            }
+        }
+        return headerValues;
+    }
 }

--- a/alfredo/src/main/java/com/cloudera/alfredo/client/KerberosAuthenticator.java
+++ b/alfredo/src/main/java/com/cloudera/alfredo/client/KerberosAuthenticator.java
@@ -43,7 +43,11 @@ import java.security.AccessController;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
 import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
+
+import static com.cloudera.alfredo.client.AuthenticatedURL.readHeaderField;
 
 /**
  * The <code>KerberosAuthenticator</code> implements the Kerberos SPNEGO authentication sequence.
@@ -59,6 +63,11 @@ public class KerberosAuthenticator implements Authenticator {
      * HTTP header used by the SPNEGO server endpoint during an authentication sequence.
      */
     public static String WWW_AUTHENTICATE = "WWW-Authenticate";
+
+    /**
+     * HTTP header used by the SPNEGO server endpoint during an authentication sequence.
+     */
+    public static String CONTENT_LENGTH = "Content-Length";
 
     /**
      * HTTP header used by the SPNEGO client endpoint during an authentication sequence.
@@ -237,19 +246,19 @@ public class KerberosAuthenticator implements Authenticator {
      * RFC-7235 states that WWW-Authenticate header may contain more than one challenge,
      * see https://tools.ietf.org/html/rfc7235#page-7. Challenges must be separated by ", ".
      *
-     * Visible for testing
      */
     private boolean isNegotiate() throws IOException {
-        boolean negotiate = false;
         if (conn.getResponseCode() == HttpURLConnection.HTTP_UNAUTHORIZED) {
-            String authHeader = conn.getHeaderField(WWW_AUTHENTICATE);
-            if (authHeader != null) {
-                String trimmedAuthHeader = authHeader.trim();
-                negotiate = trimmedAuthHeader.startsWith(NEGOTIATE) ||
-                        trimmedAuthHeader.contains(COMMA_PREFIXED_NEGOTIATE);
+            List<String> headerValues = readHeaderField(conn, WWW_AUTHENTICATE);
+            for (String value : headerValues) {
+                String trimmedAuthHeader = (value == null) ? "" : value.trim();
+                if (trimmedAuthHeader.startsWith(NEGOTIATE) ||
+                        trimmedAuthHeader.contains(COMMA_PREFIXED_NEGOTIATE)) {
+                    return true;
+                }
             }
         }
-        return negotiate;
+        return false;
     }
 
     /**
@@ -355,14 +364,18 @@ public class KerberosAuthenticator implements Authenticator {
     private byte[] readToken() throws IOException, AuthenticationException {
         int status = conn.getResponseCode();
         if (status == HttpURLConnection.HTTP_OK || status == HttpURLConnection.HTTP_UNAUTHORIZED) {
-            String authHeader = conn.getHeaderField(WWW_AUTHENTICATE);
-            if (authHeader == null || !authHeader.trim().startsWith(NEGOTIATE)) {
+            List<String> authHeaders = readHeaderField(conn, WWW_AUTHENTICATE);
+            if (authHeaders.isEmpty()) {
                 throw new AuthenticationException("Invalid SPNEGO sequence, '" + WWW_AUTHENTICATE +
-                                                  "' header incorrect: " + authHeader,
-                                                  AuthenticationException.AuthenticationExceptionCode.INVALID_SPNEGO_SEQUENCE);
+                        "' header missing",
+                        AuthenticationException.AuthenticationExceptionCode.INVALID_SPNEGO_SEQUENCE);
             }
-            String negotiation = authHeader.trim().substring((NEGOTIATE + " ").length()).trim();
-            return base64.decode(negotiation);
+            for (String authHeader : authHeaders) {
+                if (authHeader != null && authHeader.trim().startsWith(NEGOTIATE)) {
+                    String negotiation = authHeader.trim().substring((NEGOTIATE + " ").length()).trim();
+                    return base64.decode(negotiation);
+                }
+            }
         }
         throw new AuthenticationException("Invalid SPNEGO sequence, status code: " + status,
                 AuthenticationException.AuthenticationExceptionCode.INVALID_SPNEGO_SEQUENCE);

--- a/alfredo/src/main/java/com/cloudera/alfredo/server/KerberosAuthenticationHandler.java
+++ b/alfredo/src/main/java/com/cloudera/alfredo/server/KerberosAuthenticationHandler.java
@@ -272,8 +272,9 @@ public class KerberosAuthenticationHandler implements AuthenticationHandler {
                                 response.setHeader(KerberosAuthenticator.WWW_AUTHENTICATE,
                                                    KerberosAuthenticator.NEGOTIATE + " " + authenticate);
                             }
-                            if (!gssContext.isEstablished()) {
+                            if (!gssContext.isEstablished() || gssContext.getSrcName() == null) {
                                 response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                                response.setHeader(KerberosAuthenticator.CONTENT_LENGTH, "0");
                                 LOG.trace("SPNEGO in progress");
                             }
                             else {

--- a/alfredo/src/test/java/com/cloudera/alfredo/client/TestAuthenticatedURL.java
+++ b/alfredo/src/test/java/com/cloudera/alfredo/client/TestAuthenticatedURL.java
@@ -17,14 +17,12 @@
  */
 package com.cloudera.alfredo.client;
 
+import com.google.common.collect.Lists;
 import junit.framework.TestCase;
 import org.mockito.Mockito;
 
 import java.net.HttpURLConnection;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 /**
  *
@@ -116,6 +114,22 @@ public class TestAuthenticatedURL extends TestCase {
         catch (Exception ex) {
             fail();
         }
+    }
+
+    public void testCaseInsensitiveHeaderExtraction() {
+        HttpURLConnection conn = Mockito.mock(HttpURLConnection.class);
+
+        Map<String, List<String>> headers = new HashMap<String, List<String>>();
+        headers.put("header", Lists.newArrayList("value 1"));
+        headers.put("HEADER", Lists.newArrayList("value 2"));
+        headers.put("hEadEr", Lists.newArrayList("value 3"));
+        headers.put(null, Lists.newArrayList("value X"));
+
+        Mockito.when(conn.getHeaderFields()).thenReturn(headers);
+
+        List<String> values = AuthenticatedURL.readHeaderField(conn, "headeR");
+
+        assertEquals(values, Lists.newArrayList("value 1", "value 2", "value 3"));
     }
 
 }


### PR DESCRIPTION
Alfredo's approach to WWW-Authentication header parsing is far from
ideal. Look into https://tools.ietf.org/html/rfc7235#page-7 for details.

By this change we push Alfredo a bit closer to specification. Now
Alfredo is able to find Negotiate challenge in WWW-Authentication header
value that contains more than one challenge. Eg.
WWW-Authenticate: Basic real="xtz", Negotiate